### PR TITLE
Run tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,9 +60,12 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DONDSELSOLVER_BUILD_TESTS=ON
         -S ${{ github.workspace }}
 
     - name: Build
       # Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }} -j 2
 
+    - name: Test
+      run: ctest --test-dir ${{ steps.strings.outputs.build-output-dir }}


### PR DESCRIPTION
A copy of https://github.com/Ondsel-Development/OndselSolver/pull/83

Needs fixing for Windows.

Don't know if this is change is wanted but I was interested to see because when I run locally I get:

```
 11 - OndselSolver.Gears (Subprocess aborted)
 12 - OndselSolver.anglejoint (Subprocess aborted)
 13 - OndselSolver.constvel (Subprocess aborted)
 14 - OndselSolver.rackscrew (Subprocess aborted)
 15 - OndselSolver.planarbug (Subprocess aborted)
 18 - OndselSolver.piston (Subprocess aborted)
```

Failing tests apparently caused by C++ class name mangling:

https://github.com/gentoo/gentoo/blob/1896fac74ffa1cdb67fd9c9d3d85a618096c5d40/sci-libs/ondselsolver/files/ondselsolver-1.0.1-properly-demangle-typenames.patch
