### PR TITLE
Fix build on GCC

### DIFF
--- a/OndselSolver/FunctionXY.cpp
+++ b/OndselSolver/FunctionXY.cpp
@@ -6,6 +6,7 @@
  *   See LICENSE file for details about copyright.                         *
  ***************************************************************************/
 
+#include <algorithm>
 #include "FunctionXY.h"
 #include "Sum.h"
 #include "Constant.h"

--- a/OndselSolver/Power.cpp
+++ b/OndselSolver/Power.cpp
@@ -6,6 +6,7 @@
  *   See LICENSE file for details about copyright.                         *
  ***************************************************************************/
 
+#include <algorithm>
 #include "Power.h"
 #include "Constant.h"
 #include "Ln.h"


### PR DESCRIPTION
Adds <algorithm> include to two source files where libstdc++ does not indirectly include them. required since calls added to find_if where added.