### PR TITLE
OndselSolver.pc: support absolute cmake install path

### DIFF
--- a/OndselSolver.pc.in
+++ b/OndselSolver.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
nixpkgs use absolute CMAKE_INSTALL_* path during cmake configure phase. This pull request remove the need to patch freecad submodule OndselSolver in nixpkgs:
https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/fr/freecad/0002-FreeCad-OndselSolver-pkgconfig.patch.

