### PR TITLE
Changed n and m from 1 indexed to zero indexed by adding - 1

### DIFF
--- a/OndselSolver/GESpMatFullPv.cpp
+++ b/OndselSolver/GESpMatFullPv.cpp
@@ -115,8 +115,8 @@ void GESpMatFullPv::backSubstituteIntoDU()
 //    assert(n < localLen);
 
 	answerX = std::make_shared<FullColumn<double>>(m);
-	auto jn = colOrder->at(n);
-	answerX->at(jn) = rightHandSideB->at(m) / matrixA->at(m)->at(jn);
+	auto jn = colOrder->at(n - 1);
+	answerX->at(jn) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(jn);
 	//auto rhsZeroElement = this->rhsZeroElement();
 	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{


### PR DESCRIPTION
This PR fixes https://github.com/FreeCAD/FreeCAD/issues/18626

Here's an analysis done by Claude Code, and checked by me. When the fix was applied the bug appeared to be resolved.

I recommend that someone who understands the nuances of the solver please be sure to check the math on this before merging in case I am missing an important detail.

If this analysis is correct, there is another error that should be fixed at GEFullMat.cpp (line 27)
```cpp
double sum = answerX->at(n) * rowi->at(n);  // ❌ BUG: n is out of bounds!
```

I haven't found a test to verify, so have not included that fix in this PR.

## This section provides step-by-step verifiable evidence for why lines 118-119 must use `n-1` and `m-1` instead of `n` and `m`.

### Step 1: Verify colOrder Array Allocation

**File:** `GESpMatFullPv.cpp`
**Line 155:**
```cpp
colOrder = std::make_shared<FullRow<size_t>>(n);
```

**Verify FullRow Inherits from std::vector:**

The inheritance chain is:
```
FullRow<T> → FullVector<T> → Array<T> → std::vector<T>
```

**Proof:**
- **Array.h line 27:** `class Array : public std::vector<T>`
- **FullVector.h line 18:** `class FullVector : public Array<T>`
- **FullRow.h line 31:** `class FullRow : public FullVector<T>`

Therefore, `FullRow<size_t>` ultimately inherits from `std::vector<size_t>`.

**Verification:**
- `colOrder` is allocated with size `n`
- As a `std::vector`, it uses 0-based indexing
- **Valid indices are: `0, 1, 2, 3, ..., n-1`** (total of `n` elements)
- **Invalid index: `n`** (this is one past the end)

### Step 2: Understand What Back-Substitution Must Do

**Context:** Back-substitution solves for `n` unknowns: `x[0], x[1], x[2], ..., x[n-1]`

**Algorithm:** Start from the last equation and work backwards
- Process equation at index `n-1` first
- Then process equations `n-2, n-3, ..., 1, 0`

### Step 3: Analyze the Loop Structure

**File:** `GESpMatFullPv.cpp`
**Line 121:**
```cpp
for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)
```

**Verification:**
- Loop variable `i` starts at `n-2`
- Loop continues while `i >= 0`
- Loop decrements: `i--`
- **Loop iterations process `i` values: `n-2, n-3, n-4, ..., 2, 1, 0`**
- **Total iterations: `n-1`** (from `n-2` down to `0` inclusive)

### Step 4: What Index Does the Loop Access in colOrder?

**File:** `GESpMatFullPv.cpp`
**Line 136 (inside the loop):**
```cpp
auto ji = colOrder->at(i);
```

**Verification:**
- This line accesses `colOrder` at index `i`
- Since `i` ranges over `n-2, n-3, ..., 1, 0`
- **The loop accesses `colOrder` at indices: `n-2, n-3, n-4, ..., 2, 1, 0`**

### Step 5: What Index is MISSING from colOrder?

**Analysis:**
- Valid indices in `colOrder`: `0, 1, 2, ..., n-2, n-1`
- Loop accesses indices: `0, 1, 2, ..., n-2`
- **Missing index: `n-1`**

**Conclusion:** Line 118 (before the loop) MUST access `colOrder->at(n-1)` to process the missing equation.

### Step 6: What Does Line 118 ACTUALLY Do? (The Bug - Part 1)

**File:** `GESpMatFullPv.cpp`
**Line 118:**
```cpp
auto jn = colOrder->at(n);  // ❌ BUG
```

**Verification:**
- Line 118 tries to access `colOrder->at(n)`
- But `n` is NOT a valid index (valid range: `0` to `n-1`)
- **This causes `std::out_of_range` exception**

### Step 7: Verify m == n (Square Matrix Assertion)

**File:** `GESpMatFullPv.cpp`
**Line 110:**
```cpp
assert(m == n);
```

**Verification:**
- The algorithm REQUIRES a square matrix
- Number of rows (`m`) MUST equal number of columns (`n`)
- Therefore: **`m == n` throughout this function**
- This means: accessing index `m` is equivalent to accessing index `n` (both out of bounds)

### Step 8: Verify matrixA Allocation

**File:** `GESpMatFullPv.cpp`
**Line 152 (in preSolvewithsaveOriginal):**
```cpp
matrixA = std::make_shared<SparseMatrix<double>>(m);
```

**Verification:**
- `matrixA` is allocated with `m` rows
- Valid row indices: `0, 1, 2, ..., m-1`
- **Invalid row index: `m`** (one past the end)

### Step 9: Verify rightHandSideB Allocation

**File:** `GESpMatFullPv.cpp`
**Lines 163-167 (in preSolvewithsaveOriginal):**
```cpp
if (saveOriginal) {
    rightHandSideB = fullCol->copy();
}
else {
    rightHandSideB = fullCol;
}
```

**Context:** The input `fullCol` is a column vector with `m` entries (one per row/equation)

**Verification:**
- `rightHandSideB` has `m` entries
- Valid indices: `0, 1, 2, ..., m-1`
- **Invalid index: `m`** (one past the end)

### Step 10: What Indices Does the Loop Access for matrixA and rightHandSideB?

**File:** `GESpMatFullPv.cpp`
**Line 123 (inside loop - accessing matrixA):**
```cpp
auto& rowi = matrixA->at(i);
```

**Line 137 (inside loop - accessing rightHandSideB):**
```cpp
answerX->at(ji) = (rightHandSideB->at(i) - sum) / duii;
```

**Verification:**
- Loop variable `i` ranges: `n-2, n-3, ..., 1, 0`
- Since `m == n`, this is also: `m-2, m-3, ..., 1, 0`
- **Loop accesses `matrixA->at(i)` for `i ∈ {0, 1, ..., m-2}`**
- **Loop accesses `rightHandSideB->at(i)` for `i ∈ {0, 1, ..., m-2}`**

### Step 11: What Index is MISSING for matrixA and rightHandSideB?

**Analysis:**
- Valid row indices in `matrixA`: `0, 1, 2, ..., m-2, m-1`
- Loop accesses rows: `0, 1, 2, ..., m-2`
- **Missing row index: `m-1`**

**Same for rightHandSideB:**
- Valid indices: `0, 1, 2, ..., m-2, m-1`
- Loop accesses: `0, 1, 2, ..., m-2`
- **Missing index: `m-1`**

**Conclusion:** Line 119 MUST access row `m-1` for both `matrixA` and `rightHandSideB`.

### Step 12: What Does Line 119 ACTUALLY Do? (The Bug - Part 2)

**File:** `GESpMatFullPv.cpp`
**Line 119:**
```cpp
answerX->at(jn) = rightHandSideB->at(m) / matrixA->at(m)->at(jn);  // ❌ BUG
```

**Verification:**
- Tries to access `rightHandSideB->at(m)` where `m` is OUT OF BOUNDS ❌
- Tries to access `matrixA->at(m)` where `m` is OUT OF BOUNDS ❌
- **Both cause `std::out_of_range` exception**

### Step 13: Complete Fix for Lines 118-119

**Before (BUGGY):**
```cpp
auto jn = colOrder->at(n);           // ❌ OUT OF BOUNDS
answerX->at(jn) = rightHandSideB->at(m) / matrixA->at(m)->at(jn);  // ❌ OUT OF BOUNDS (both m accesses)
```

**After (CORRECT):**
```cpp
auto jn = colOrder->at(n - 1);       // ✅ VALID (last column)
answerX->at(jn) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(jn);  // ✅ VALID (last row)
```

### Step 14: Verification Table

| Array | Size | Valid Indices | Buggy Access | Fixed Access |
|-------|------|---------------|--------------|--------------|
| `colOrder` | `n` | `0` to `n-1` | `colOrder->at(n)` ❌ | `colOrder->at(n-1)` ✅ |
| `rightHandSideB` | `m` | `0` to `m-1` | `rightHandSideB->at(m)` ❌ | `rightHandSideB->at(m-1)` ✅ |
| `matrixA` (rows) | `m` | `0` to `m-1` | `matrixA->at(m)` ❌ | `matrixA->at(m-1)` ✅ |

**Note:** Since `m == n` (line 110 assertion), `m-1` and `n-1` refer to the same value.

### Step 15: Coverage Analysis

**After fix:**
- Line 118 processes: `colOrder->at(n-1)` ✅
- Loop processes: `colOrder->at(n-2), colOrder->at(n-3), ..., colOrder->at(0)` ✅
- **Total coverage: All valid indices from `0` to `n-1`** ✅

**With bug:**
- Line 118 attempts: `colOrder->at(n)` ❌ (exception thrown, program crashes)
- Loop never runs because exception occurs first
- **Result: Program crash with `std::out_of_range`**

### Step 16: Concrete Example (3×3 System)

For n=3, m=3 system:
- Valid array indices: **0, 1, 2**
- Back-substitution order:
  1. **Lines 118-119:** Solve for x[2] using row 2 and column 2 ✅ (requires n-1=2, m-1=2)
  2. **Loop iteration i=1:** Solve for x[1] using row 1 ✅
  3. **Loop iteration i=0:** Solve for x[0] using row 0 ✅

**With Current Buggy Code (n=3, m=3):**
```cpp
auto jn = colOrder->at(3);  // ❌ Out of bounds! (valid: 0, 1, 2)
// → Exception: std::out_of_range in vector::_M_range_check
```

## Evidence from Codebase

### 5.1 Sibling Implementation Uses n-1

The OndselSolver repository contains a sibling implementation of back-substitution that correctly uses `n-1`:

**GESpMatParPv.cpp (Line 55):**
```cpp
answerX->at(n - 1) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(n - 1);  // ✅ Correct
```

**Note:** GESpMatParPv.cpp uses a simpler partial pivoting approach (no `colOrder` permutation), but still correctly uses `n-1` as the last valid index.
