### PR TITLE
Fix off-by-one in GEFullMat::backSubstituteIntoDU()

### DIFF
--- a/OndselSolver/GEFullMat.cpp
+++ b/OndselSolver/GEFullMat.cpp
@@ -24,7 +24,7 @@ void GEFullMat::backSubstituteIntoDU()
 	for (ssize_t i = (ssize_t)n - 2; i >= 0; i--)	//Use ssize_t because of decrement
 	{
 		auto rowi = matrixA->at(i);
-		double sum = answerX->at(n) * rowi->at(n);
+		double sum = answerX->at(n - 1) * rowi->at(n - 1);
 		for (size_t j = i + 1; j < n - 1; j++)
 		{
 			sum += answerX->at(j) * rowi->at(j);


### PR DESCRIPTION


  Body:

  Summary

If you look at this PR https://github.com/FreeCAD/OndselSolver/pull/12 It had already recommended this change but seemed to have been overlooked.


Some info from Claude:

  - Fix out-of-bounds vector access in GEFullMat::backSubstituteIntoDU() where answerX->at(n) and rowi->at(n) accessed index n in
  vectors of size n (valid range: 0 to n-1)

  Details

  GEFullMat::backSubstituteIntoDU() initializes the back-substitution correctly on line 23 using n - 1:
  answerX->at(n - 1) = rightHandSideB->at(m - 1) / matrixA->at(m - 1)->at(n - 1);

  But the first iteration of the loop used n instead of n - 1:
  double sum = answerX->at(n) * rowi->at(n);  // out of bounds

  This is the same class of bug fixed in GESpMatFullPv::backSubstituteIntoDU() and causes a vector::_M_range_check exception at runtime.

  GEFullMat is the base class for GEFullMatParPv and GEFullMatFullPv, neither of which override backSubstituteIntoDU(), so this affects
  both full-pivot and partial-pivot dense matrix solves.