### PR TITLE
switch to noop in postSolve function

### DIFF
--- a/OndselSolver/GESpMatFullPv.cpp
+++ b/OndselSolver/GESpMatFullPv.cpp
@@ -140,7 +140,6 @@ void GESpMatFullPv::backSubstituteIntoDU()
 
 void GESpMatFullPv::postSolve()
 {
-	throw SimulationStoppingError("To be implemented.");
 }
 
 void GESpMatFullPv::preSolvewithsaveOriginal(SpMatDsptr spMat, FColDsptr fullCol, bool saveOriginal)


### PR DESCRIPTION
I found that this thrown error will cause the solver messages status on the right side to complain that the solve failed because it could not converge.

Terminal error: `107.488 <Assembly> AssemblyObject.cpp(177): Solve failed: To be implemented.`

After the error is replaced with a no-op, the solver messages correctly show the number of unconstrained degrees of freedom.

Here is the .asmt file if that is needed.
[XMM62400.zip](https://github.com/user-attachments/files/25329506/XMM62400.zip)
