### PR TITLE
Assembly: keep active drag limits while resolving new violations

### DIFF
--- a/OndselSolver/PosICDragLimitNewtonRaphson.cpp
+++ b/OndselSolver/PosICDragLimitNewtonRaphson.cpp
@@ -45,18 +45,29 @@ void MbD::PosICDragLimitNewtonRaphson::run()
 		return;
 	}
 	auto limits = system->limits();
-	std::partition(limits->begin(), limits->end(), [](auto limit) { return !limit->satisfied(); });
-	//Violated limits are in front.
-	for (auto it = limits->begin(); it != limits->end(); it++) {
-		auto limit = *it;
-		limit->activate();
+	for (size_t i = 0; i < limits->size(); i++) {
+		bool activatedLimit = false;
+		for (auto& limit : *limits) {
+			// Keep earlier violated limits active while adding newly violated ones.
+			if (!limit->active && !limit->satisfied()) {
+				limit->activate();
+				activatedLimit = true;
+			}
+		}
+		if (!activatedLimit) {
+			break;
+		}
+
 		preRun();
 		initializeLocally();
 		initializeGlobally();
 		iterate();
 		postRun();
-		system->deactivateLimits();
-		if (system->limitsSatisfied()) return;
+		if (system->limitsSatisfied()) {
+			system->deactivateLimits();
+			return;
+		}
 	}
-	throw SimulationStoppingError("Limits cannot be satisfiled.");
+	system->deactivateLimits();
+	throw SimulationStoppingError("Limits cannot be satisfied.");
 }


### PR DESCRIPTION
Fix https://github.com/FreeCAD/FreeCAD/issues/27214

Fixes an Assembly drag solver issue where a chain of limited slider joints could jump between valid positions after multiple limits were reached. During drag limit resolution, the solver previously tried violated limits one at a time and deactivated each before checking the next one. In a double-slider setup, this allowed the first slider limit to be released while satisfying the second slider limit, causing the dragged assembly to snap back and repeat. This changes PosICDragLimitNewtonRaphson to accumulate active violated limits during the drag projection, so earlier reached limits remain enforced while newly violated limits are added.

Tested with the provided file, the bug is fixed.