### PR TITLE
Support coaxial gear constraints

### DIFF
--- a/OndselSolver/ASMTGearJoint.cpp
+++ b/OndselSolver/ASMTGearJoint.cpp
@@ -7,7 +7,10 @@
  ***************************************************************************/
 #include <fstream>	
 
+#include "ASMTAssembly.h"
 #include "ASMTGearJoint.h"
+#include "ASMTMarker.h"
+#include "EndFramec.h"
 #include "GearJoint.h"
 #include "SimulationStoppingError.h"
 
@@ -28,8 +31,21 @@ std::shared_ptr<ItemIJ> MbD::ASMTGearJoint::mbdClassNew()
 void MbD::ASMTGearJoint::parseASMT(std::vector<std::string>& lines)
 {
 	ASMTJoint::parseASMT(lines);
+	readMarkerK(lines);
 	readRadiusI(lines);
 	readRadiusJ(lines);
+}
+
+void MbD::ASMTGearJoint::readMarkerK(std::vector<std::string>& lines)
+{
+	if (lines.empty() || lines[0].find("MarkerK") == std::string::npos) {
+		markerK.clear();
+	}
+	else {
+		lines.erase(lines.begin());
+		markerK = readString(lines[0]);
+		lines.erase(lines.begin());
+	}
 }
 
 void MbD::ASMTGearJoint::readRadiusI(std::vector<std::string>& lines)
@@ -63,11 +79,24 @@ void MbD::ASMTGearJoint::createMbD(std::shared_ptr<System> mbdSys, std::shared_p
 	auto gearJoint = std::static_pointer_cast<GearJoint>(mbdObject);
 	gearJoint->radiusI = radiusI;
 	gearJoint->radiusJ = radiusJ;
+	if (!markerK.empty()) {
+		auto mrkK = std::static_pointer_cast<EndFramec>(root()->markerAt(markerK)->mbdObject);
+		gearJoint->setCarrierFrame(mrkK);
+	}
+}
+
+void MbD::ASMTGearJoint::setMarkerK(const std::string& mkrK)
+{
+	markerK = mkrK;
 }
 
 void MbD::ASMTGearJoint::storeOnLevel(std::ofstream& os, size_t level)
 {
 	ASMTJoint::storeOnLevel(os, level);
+	if (!markerK.empty()) {
+		storeOnLevelString(os, level + 1, "MarkerK");
+		storeOnLevelString(os, level + 2, markerK);
+	}
 	storeOnLevelString(os, level + 1, "radiusI");
 	storeOnLevelDouble(os, level + 2, radiusI);
 	storeOnLevelString(os, level + 1, "radiusJ");

--- a/OndselSolver/ASMTGearJoint.h
+++ b/OndselSolver/ASMTGearJoint.h
@@ -18,12 +18,14 @@ namespace MbD {
         static std::shared_ptr<ASMTGearJoint> With();
         std::shared_ptr<ItemIJ> mbdClassNew() override;
         void parseASMT(std::vector<std::string>& lines) override;
+        void readMarkerK(std::vector<std::string>& lines);
         void readRadiusI(std::vector<std::string>& lines);
         void readRadiusJ(std::vector<std::string>& lines);
         void createMbD(std::shared_ptr<System> mbdSys, std::shared_ptr<Units> mbdUnits) override;
+        void setMarkerK(const std::string& mkrK);
         void storeOnLevel(std::ofstream& os, size_t level) override;
 
+        std::string markerK;
         double radiusI = 0.0, radiusJ = 0.0, aConstant = 0.0;
     };
 }
-

--- a/OndselSolver/CMakeLists.txt
+++ b/OndselSolver/CMakeLists.txt
@@ -100,6 +100,7 @@ set(ONDSELSOLVER_SRC
         Constant.cpp
         ConstantGravity.cpp
         ConstantVelocityJoint.cpp
+        CoaxialGearConstraintIJ.cpp
         Constraint.cpp
         ConstraintIJ.cpp
         ConstraintSet.cpp
@@ -416,6 +417,7 @@ set(ONDSELSOLVER_HEADERS
         Constant.h
         ConstantGravity.h
         ConstantVelocityJoint.h
+        CoaxialGearConstraintIJ.h
         Constraint.h
         ConstraintIJ.h
         ConstraintSet.h

--- a/OndselSolver/CoaxialGearConstraintIJ.cpp
+++ b/OndselSolver/CoaxialGearConstraintIJ.cpp
@@ -1,0 +1,228 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Ondsel, Inc.                                       *
+ *                                                                         *
+ *   This file is part of OndselSolver.                                    *
+ *                                                                         *
+ *   See LICENSE file for details about copyright.                         *
+ ***************************************************************************/
+
+#include "CoaxialGearConstraintIJ.h"
+
+#include <cassert>
+#include <limits>
+#include <utility>
+
+#include "AngleZIeqcJeqc.h"
+#include "EndFrameqc.h"
+#include "FullColumn.h"
+#include "FullMatrix.h"
+#include "FullRow.h"
+#include "SimulationStoppingError.h"
+
+using namespace MbD;
+
+MbD::CoaxialGearConstraintIJ::CoaxialGearConstraintIJ(
+    EndFrmsptr frmi,
+    EndFrmsptr frmj,
+    EndFrmsptr frmk
+) : frmI(std::move(frmi)), frmJ(std::move(frmj)), frmK(std::move(frmk))
+{}
+
+std::shared_ptr<CoaxialGearConstraintIJ> MbD::CoaxialGearConstraintIJ::With(
+    EndFrmsptr frmi,
+    EndFrmsptr frmj,
+    EndFrmsptr frmk
+)
+{
+    assert(frmi->isEndFrameqc());
+    assert(frmj->isEndFrameqc());
+    assert(frmk->isEndFrameqc());
+
+    auto constraint = std::make_shared<CoaxialGearConstraintIJ>(frmi, frmj, frmk);
+    constraint->initialize();
+    return constraint;
+}
+
+void MbD::CoaxialGearConstraintIJ::calcPostDynCorrectorIteration()
+{
+    angleKI->calcPostDynCorrectorIteration();
+    angleKJ->calcPostDynCorrectorIteration();
+
+    const double gearRatio = ratio();
+    aG = angleKJ->value() + (gearRatio * angleKI->value()) - aConstant;
+
+    pGpEI = angleKI->pvaluepEJ()->times(gearRatio);
+    pGpEJ = angleKJ->pvaluepEJ();
+    pGpEK = angleKJ->pvaluepEI()->plusFullRow(angleKI->pvaluepEI()->times(gearRatio));
+
+    ppGpEIpEI = angleKI->ppvaluepEJpEJ()->times(gearRatio);
+    ppGpEJpEJ = angleKJ->ppvaluepEJpEJ();
+    ppGpEKpEK = angleKJ->ppvaluepEIpEI()->plusFullMatrix(
+        angleKI->ppvaluepEIpEI()->times(gearRatio)
+    );
+    ppGpEKpEI = angleKI->ppvaluepEIpEJ()->times(gearRatio);
+    ppGpEKpEJ = angleKJ->ppvaluepEIpEJ();
+}
+
+void MbD::CoaxialGearConstraintIJ::fillAccICIterError(FColDsptr col)
+{
+    col->atiplusFullVectortimes(iqEI, pGpEI, lam);
+    col->atiplusFullVectortimes(iqEJ, pGpEJ, lam);
+    col->atiplusFullVectortimes(iqEK, pGpEK, lam);
+
+    auto frmIeqc = std::static_pointer_cast<EndFrameqc>(frmI);
+    auto frmJeqc = std::static_pointer_cast<EndFrameqc>(frmJ);
+    auto frmKeqc = std::static_pointer_cast<EndFrameqc>(frmK);
+
+    auto qEdotI = frmIeqc->qEdot();
+    auto qEdotJ = frmJeqc->qEdot();
+    auto qEdotK = frmKeqc->qEdot();
+
+    double sum = 0.0;
+    sum += pGpEI->timesFullColumn(frmIeqc->qEddot());
+    sum += pGpEJ->timesFullColumn(frmJeqc->qEddot());
+    sum += pGpEK->timesFullColumn(frmKeqc->qEddot());
+    sum += qEdotI->transposeTimesFullColumn(ppGpEIpEI->timesFullColumn(qEdotI));
+    sum += qEdotJ->transposeTimesFullColumn(ppGpEJpEJ->timesFullColumn(qEdotJ));
+    sum += qEdotK->transposeTimesFullColumn(ppGpEKpEK->timesFullColumn(qEdotK));
+    sum += 2.0
+        * qEdotK->transposeTimesFullColumn(ppGpEKpEI->timesFullColumn(qEdotI));
+    sum += 2.0
+        * qEdotK->transposeTimesFullColumn(ppGpEKpEJ->timesFullColumn(qEdotJ));
+    col->atiplusNumber(iG, sum);
+}
+
+void MbD::CoaxialGearConstraintIJ::fillPosICError(FColDsptr col)
+{
+    Constraint::fillPosICError(col);
+    col->atiplusFullVectortimes(iqEI, pGpEI, lam);
+    col->atiplusFullVectortimes(iqEJ, pGpEJ, lam);
+    col->atiplusFullVectortimes(iqEK, pGpEK, lam);
+}
+
+void MbD::CoaxialGearConstraintIJ::fillPosICJacob(SpMatDsptr mat)
+{
+    mat->atijplusFullRow(iG, iqEI, pGpEI);
+    mat->atijplusFullColumn(iqEI, iG, pGpEI->transpose());
+    mat->atijplusFullRow(iG, iqEJ, pGpEJ);
+    mat->atijplusFullColumn(iqEJ, iG, pGpEJ->transpose());
+    mat->atijplusFullRow(iG, iqEK, pGpEK);
+    mat->atijplusFullColumn(iqEK, iG, pGpEK->transpose());
+
+    mat->atijplusFullMatrixtimes(iqEI, iqEI, ppGpEIpEI, lam);
+    mat->atijplusFullMatrixtimes(iqEJ, iqEJ, ppGpEJpEJ, lam);
+    mat->atijplusFullMatrixtimes(iqEK, iqEK, ppGpEKpEK, lam);
+
+    auto ppGpEKpEIlam = ppGpEKpEI->times(lam);
+    mat->atijplusFullMatrix(iqEK, iqEI, ppGpEKpEIlam);
+    mat->atijplusTransposeFullMatrix(iqEI, iqEK, ppGpEKpEIlam);
+
+    auto ppGpEKpEJlam = ppGpEKpEJ->times(lam);
+    mat->atijplusFullMatrix(iqEK, iqEJ, ppGpEKpEJlam);
+    mat->atijplusTransposeFullMatrix(iqEJ, iqEK, ppGpEKpEJlam);
+}
+
+void MbD::CoaxialGearConstraintIJ::fillPosKineJacob(SpMatDsptr mat)
+{
+    mat->atijplusFullRow(iG, iqEI, pGpEI);
+    mat->atijplusFullRow(iG, iqEJ, pGpEJ);
+    mat->atijplusFullRow(iG, iqEK, pGpEK);
+}
+
+void MbD::CoaxialGearConstraintIJ::fillVelICJacob(SpMatDsptr mat)
+{
+    mat->atijplusFullRow(iG, iqEI, pGpEI);
+    mat->atijplusFullColumn(iqEI, iG, pGpEI->transpose());
+    mat->atijplusFullRow(iG, iqEJ, pGpEJ);
+    mat->atijplusFullColumn(iqEJ, iG, pGpEJ->transpose());
+    mat->atijplusFullRow(iG, iqEK, pGpEK);
+    mat->atijplusFullColumn(iqEK, iG, pGpEK->transpose());
+}
+
+void MbD::CoaxialGearConstraintIJ::initialize()
+{
+    Constraint::initialize();
+    angleKI = AngleZIeqcJeqc::With(frmK, frmI);
+    angleKJ = AngleZIeqcJeqc::With(frmK, frmJ);
+}
+
+void MbD::CoaxialGearConstraintIJ::initializeGlobally()
+{
+    angleKI->initializeGlobally();
+    angleKJ->initializeGlobally();
+}
+
+void MbD::CoaxialGearConstraintIJ::initializeLocally()
+{
+    angleKI->initializeLocally();
+    angleKJ->initializeLocally();
+}
+
+void MbD::CoaxialGearConstraintIJ::postInput()
+{
+    angleKI->postInput();
+    angleKJ->postInput();
+    if (aConstant == std::numeric_limits<double>::min()) {
+        aConstant = angleKJ->value() + (ratio() * angleKI->value());
+    }
+    Constraint::postInput();
+}
+
+void MbD::CoaxialGearConstraintIJ::postPosICIteration()
+{
+    angleKI->postPosICIteration();
+    angleKJ->postPosICIteration();
+    Constraint::postPosICIteration();
+}
+
+void MbD::CoaxialGearConstraintIJ::preAccIC()
+{
+    angleKI->preAccIC();
+    angleKJ->preAccIC();
+    Constraint::preAccIC();
+}
+
+void MbD::CoaxialGearConstraintIJ::prePosIC()
+{
+    angleKI->prePosIC();
+    angleKJ->prePosIC();
+    Constraint::prePosIC();
+}
+
+void MbD::CoaxialGearConstraintIJ::preVelIC()
+{
+    angleKI->preVelIC();
+    angleKJ->preVelIC();
+    Constraint::preVelIC();
+}
+
+double MbD::CoaxialGearConstraintIJ::ratio() const
+{
+    if (radiusJ == 0.0) {
+        throw SimulationStoppingError("Gear radius is zero.");
+    }
+    return radiusI / radiusJ;
+}
+
+void MbD::CoaxialGearConstraintIJ::simUpdateAll()
+{
+    angleKI->simUpdateAll();
+    angleKJ->simUpdateAll();
+    Constraint::simUpdateAll();
+}
+
+void MbD::CoaxialGearConstraintIJ::useEquationNumbers()
+{
+    auto frmIeqc = std::static_pointer_cast<EndFrameqc>(frmI);
+    auto frmJeqc = std::static_pointer_cast<EndFrameqc>(frmJ);
+    auto frmKeqc = std::static_pointer_cast<EndFrameqc>(frmK);
+
+    iqEI = frmIeqc->iqE();
+    iqEJ = frmJeqc->iqE();
+    iqEK = frmKeqc->iqE();
+}
+
+std::string MbD::CoaxialGearConstraintIJ::constraintSpec()
+{
+    return "CoaxialGearConstraintIJK";
+}

--- a/OndselSolver/CoaxialGearConstraintIJ.h
+++ b/OndselSolver/CoaxialGearConstraintIJ.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *   Copyright (c) 2023 Ondsel, Inc.                                       *
+ *                                                                         *
+ *   This file is part of OndselSolver.                                    *
+ *                                                                         *
+ *   See LICENSE file for details about copyright.                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include "Constraint.h"
+
+namespace MbD {
+    class AngleZIeqcJeqc;
+    class EndFramec;
+    using EndFrmsptr = std::shared_ptr<EndFramec>;
+
+    class CoaxialGearConstraintIJ : public Constraint
+    {
+    public:
+        CoaxialGearConstraintIJ(EndFrmsptr frmi, EndFrmsptr frmj, EndFrmsptr frmk);
+
+        static std::shared_ptr<CoaxialGearConstraintIJ> With(
+            EndFrmsptr frmi,
+            EndFrmsptr frmj,
+            EndFrmsptr frmk
+        );
+
+        void calcPostDynCorrectorIteration() override;
+        void fillAccICIterError(FColDsptr col) override;
+        void fillPosICError(FColDsptr col) override;
+        void fillPosICJacob(SpMatDsptr mat) override;
+        void fillPosKineJacob(SpMatDsptr mat) override;
+        void fillVelICJacob(SpMatDsptr mat) override;
+        void initialize() override;
+        void initializeGlobally() override;
+        void initializeLocally() override;
+        void postInput() override;
+        void postPosICIteration() override;
+        void preAccIC() override;
+        void prePosIC() override;
+        void preVelIC() override;
+        double ratio() const;
+        void simUpdateAll() override;
+        void useEquationNumbers() override;
+        std::string constraintSpec() override;
+
+        EndFrmsptr frmI, frmJ, frmK;
+        std::shared_ptr<AngleZIeqcJeqc> angleKI, angleKJ;
+        double radiusI = 0.0, radiusJ = 0.0;
+
+        FRowDsptr pGpEI, pGpEJ, pGpEK;
+        FMatDsptr ppGpEIpEI, ppGpEJpEJ, ppGpEKpEK, ppGpEKpEI, ppGpEKpEJ;
+        size_t iqEI = SIZE_MAX, iqEJ = SIZE_MAX, iqEK = SIZE_MAX;
+    };
+}

--- a/OndselSolver/GearJoint.cpp
+++ b/OndselSolver/GearJoint.cpp
@@ -6,12 +6,62 @@
  *   See LICENSE file for details about copyright.                         *
  ***************************************************************************/
  
-#include "GearJoint.h"
 #include "CREATE.h"
+#include "CoaxialGearConstraintIJ.h"
+#include "EndFramec.h"
+#include "FullColumn.h"
 #include "GearConstraintIJ.h"
+#include "GearJoint.h"
+#include "MarkerFrame.h"
+#include "PartFrame.h"
+#include "SimulationStoppingError.h"
 #include "System.h"
 
+#include <cmath>
+#include <limits>
+
 using namespace MbD;
+
+namespace
+{
+
+constexpr double coaxialTolerance = 1.0e-9;
+
+FColDsptr frameOriginInO(const EndFrmsptr& frame)
+{
+	auto markerFrame = frame->getMarkerFrame();
+	auto partFrame = markerFrame->getPartFrame();
+	// Gear constraints are installed before end-frame caches are refreshed.
+	return partFrame->rOpO()->plusFullColumn(partFrame->aAOp()->timesFullColumn(markerFrame->rpmp));
+}
+
+FColDsptr frameZAxisInO(const EndFrmsptr& frame)
+{
+	auto markerFrame = frame->getMarkerFrame();
+	auto partFrame = markerFrame->getPartFrame();
+	return partFrame->aAOp()->timesFullMatrix(markerFrame->aApm)->column(2);
+}
+
+bool framesAreCoaxial(const EndFrmsptr& frameI, const EndFrmsptr& frameJ)
+{
+	auto axisI = frameZAxisInO(frameI);
+	auto axisJ = frameZAxisInO(frameJ);
+	const double axisILength = axisI->length();
+	const double axisJLength = axisJ->length();
+	if (axisILength <= coaxialTolerance || axisJLength <= coaxialTolerance) {
+		return false;
+	}
+
+	const double cosAngle = axisI->dot(axisJ) / (axisILength * axisJLength);
+	if (1.0 - std::abs(cosAngle) > coaxialTolerance) {
+		return false;
+	}
+
+	auto delta = frameOriginInO(frameJ)->minusFullColumn(frameOriginInO(frameI));
+	return delta->cross(axisI)->length() / axisILength <= coaxialTolerance;
+}
+
+}  // namespace
 
 MbD::GearJoint::GearJoint()
 {
@@ -31,15 +81,35 @@ MbD::GearJoint::GearJoint(const std::string& str) : Joint(str)
 //	Joint::initializeLocally();
 //}
 
+void MbD::GearJoint::setCarrierFrame(EndFrmsptr carrierFrame)
+{
+	frmK = carrierFrame;
+}
+
 void MbD::GearJoint::initializeGlobally()
 {
 	if (constraints->empty())
 	{
-		auto gearIJ = GearConstraintIJ::With(frmI, frmJ);
-		gearIJ->radiusI = radiusI;
-		gearIJ->radiusJ = radiusJ;
-		gearIJ->setConstant(std::numeric_limits<double>::min());
-		addConstraint(gearIJ);
+		if (framesAreCoaxial(frmI, frmJ)) {
+			if (!frmK) {
+				throw SimulationStoppingError(
+					"Coaxial GearJoint requires a carrier marker."
+				);
+			}
+
+			auto gearIJK = CoaxialGearConstraintIJ::With(frmI, frmJ, frmK);
+			gearIJK->radiusI = radiusI;
+			gearIJK->radiusJ = radiusJ;
+			gearIJK->setConstant(std::numeric_limits<double>::min());
+			addConstraint(gearIJK);
+		}
+		else {
+			auto gearIJ = GearConstraintIJ::With(frmI, frmJ);
+			gearIJ->radiusI = radiusI;
+			gearIJ->radiusJ = radiusJ;
+			gearIJ->setConstant(std::numeric_limits<double>::min());
+			addConstraint(gearIJ);
+		}
 		this->root()->hasChanged = true;
 	}
 	else {

--- a/OndselSolver/GearJoint.h
+++ b/OndselSolver/GearJoint.h
@@ -19,9 +19,10 @@ namespace MbD {
 		GearJoint(const std::string& str);
 
 		//void initializeLocally() override;
+		void setCarrierFrame(EndFrmsptr carrierFrame);
 		void initializeGlobally() override;
 
+		EndFrmsptr frmK;
 		double radiusI = 0.0, radiusJ = 0.0, aConstant = 0.0;
 	};
 }
-

--- a/OndselSolver/OndselSolver.vcxproj
+++ b/OndselSolver/OndselSolver.vcxproj
@@ -230,6 +230,7 @@
     <ClCompile Include="Constant.cpp" />
     <ClCompile Include="ConstantGravity.cpp" />
     <ClCompile Include="ConstantVelocityJoint.cpp" />
+    <ClCompile Include="CoaxialGearConstraintIJ.cpp" />
     <ClCompile Include="Constraint.cpp" />
     <ClCompile Include="ConstraintIJ.cpp" />
     <ClCompile Include="ConstraintSet.cpp" />
@@ -549,6 +550,7 @@
     <ClInclude Include="Constant.h" />
     <ClInclude Include="ConstantGravity.h" />
     <ClInclude Include="ConstantVelocityJoint.h" />
+    <ClInclude Include="CoaxialGearConstraintIJ.h" />
     <ClInclude Include="Constraint.h" />
     <ClInclude Include="ConstraintIJ.h" />
     <ClInclude Include="ConstraintSet.h" />

--- a/OndselSolver/OndselSolver.vcxproj.filters
+++ b/OndselSolver/OndselSolver.vcxproj.filters
@@ -555,6 +555,9 @@
     <ClCompile Include="GearJoint.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="CoaxialGearConstraintIJ.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="PointInLineJoint.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -1512,6 +1515,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="GearJoint.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="CoaxialGearConstraintIJ.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="PointInLineJoint.h">


### PR DESCRIPTION
Fixes coaxial gear/belt joints by letting GearJoint detect when its two markers are coaxial and switch to a new carrier-based internal constraint. The new constraint uses an optional MarkerK carrier frame so the gear ratio is measured relative to the common support instead of relying on the zero-length center-to-center vector.

Fix in part https://github.com/FreeCAD/FreeCAD/issues/19246